### PR TITLE
flip coverage plot by strand

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^data-raw$
 ^PTK2B.png$
 
+^wiggleplotr\.Rproj$

--- a/R/makePlots.R
+++ b/R/makePlots.R
@@ -1,25 +1,26 @@
-plotTranscriptStructure <- function(exons_df, limits = NA, connect_exons = TRUE,  
-                                    xlabel = "Distance from gene start (bp)", transcript_label = TRUE){
-  
+plotTranscriptStructure <- function(exons_df, limits = NA, connect_exons = TRUE, xlabel = "Distance from gene start (bp)", transcript_label = TRUE){
+
+  order_func <- ifelse(diff(limits) < 0, dplyr::slice_max, dplyr::slice_min)
+
   #Extract the position for plotting transcript name
-  transcript_annot = dplyr::group_by_(exons_df, ~transcript_id) %>% 
+  transcript_annot = dplyr::group_by_(exons_df, ~transcript_id) %>%
     dplyr::filter_(~feature_type == "exon") %>%
     dplyr::arrange_('transcript_id', 'start') %>%
-    dplyr::filter(row_number() == 1)
+    order_func(start)
 
   #Create a plot of transcript structure
   plot = ggplot(exons_df) + geom_blank()
   if(connect_exons){ #Print line connecting exons
     plot = plot + geom_line(aes_(x = ~start, y = ~transcript_rank, group = ~transcript_rank, color = ~feature_type))
   }
-  plot = plot + 
-    geom_rect(aes_(xmin = ~start, 
-                   xmax = ~end, 
-                   ymax = ~transcript_rank + 0.25, 
-                   ymin = ~transcript_rank - 0.25, 
-                   fill = ~feature_type)) + 
+  plot = plot +
+    geom_rect(aes_(xmin = ~start,
+                   xmax = ~end,
+                   ymax = ~transcript_rank + 0.25,
+                   ymin = ~transcript_rank - 0.25,
+                   fill = ~feature_type)) +
     theme_light() +
-    theme(plot.margin=unit(c(0,1,1,1),"line"), 
+    theme(plot.margin=unit(c(0,1,1,1),"line"),
           axis.title.y = element_blank(),
           axis.text.y = element_blank(),
           axis.ticks.y = element_blank(),
@@ -31,16 +32,19 @@ plotTranscriptStructure <- function(exons_df, limits = NA, connect_exons = TRUE,
     xlab(xlabel) +
     facet_grid(type~.) +
     scale_y_continuous(expand = c(0.2,0.15)) +
-    scale_fill_manual(values = c("#2c7bb6","#abd9e9")) + 
+    scale_fill_manual(values = c("#2c7bb6","#abd9e9")) +
     scale_colour_manual(values = c("#2c7bb6","#abd9e9"))
   if(all(!is.na(limits))){
     plot = plot + scale_x_continuous(expand = c(0,0)) +
       coord_cartesian(xlim = limits)
   }
   if(transcript_label){
-    plot = plot + geom_text(aes_(x = ~start, 
-                                 y = ~transcript_rank + 0.30, 
-                                 label = ~transcript_label), 
+
+    label_placement <- ifelse(diff(limits) < 0, "end", "start")
+
+    plot = plot + geom_text(aes(x = .data[[label_placement]],
+                                 y = .data[["transcript_rank"]] + 0.30,
+                                 label = .data[["transcript_label"]]),
                             data = transcript_annot, hjust = 0, vjust = 0, size = 4)
 
   }
@@ -48,27 +52,28 @@ plotTranscriptStructure <- function(exons_df, limits = NA, connect_exons = TRUE,
 }
 
 makeCoveragePlot <- function(coverage_df, limits, alpha, fill_palette, coverage_type){
+
   #Plot coverage over a region
-  coverage_plot = ggplot(coverage_df, aes_(~bins, ~coverage, group = ~sample_id, alpha = ~alpha)) + 
+  coverage_plot = ggplot(coverage_df, aes_(~bins, ~coverage, group = ~sample_id, alpha = ~alpha)) +
     geom_blank() +
     theme_light()
   #Choose between plotting a line and plotting area
   if(coverage_type == "line"){
-    coverage_plot = coverage_plot + 
-      geom_line(aes_(colour = ~colour_group), alpha = alpha, position = "identity") 
+    coverage_plot = coverage_plot +
+      geom_line(aes_(colour = ~colour_group), alpha = alpha, position = "identity")
   } else if (coverage_type == "area"){
-    coverage_plot = coverage_plot + 
+    coverage_plot = coverage_plot +
       geom_area(aes_(fill = ~colour_group), alpha = alpha, position = "identity")
   } else if (coverage_type == "both"){
-    coverage_plot = coverage_plot + 
+    coverage_plot = coverage_plot +
       geom_area(aes_(fill = ~colour_group), alpha = alpha, position = "identity") +
-      geom_line(aes_(colour = ~colour_group), alpha = alpha, position = "identity") 
+      geom_line(aes_(colour = ~colour_group), alpha = alpha, position = "identity")
   } else{
     stop("Coverage type not supported.")
   }
   coverage_plot = coverage_plot +
     facet_grid(track_id~.) +
-    dataTrackTheme() + 
+    dataTrackTheme() +
     scale_x_continuous(expand = c(0,0)) +
     scale_y_continuous(expand = c(0,0)) +
     coord_cartesian(xlim = limits) +
@@ -79,15 +84,15 @@ makeCoveragePlot <- function(coverage_df, limits, alpha, fill_palette, coverage_
 }
 
 #' Make a Manahattan plot of p-values
-#' 
-#' The Manhattan plots is compatible with wiggpleplotr read coverage and transcript strucutre plots. 
-#' Can be appended to those using the cowplot::plot_grid() function. 
+#'
+#' The Manhattan plots is compatible with wiggpleplotr read coverage and transcript strucutre plots.
+#' Can be appended to those using the cowplot::plot_grid() function.
 #'
 #' @param pvalues_df Data frame of association p-values (required columns: track_id, p_nominal, pos)
-#' @param region_coords Start and end coordinates of the region to plot. 
+#' @param region_coords Start and end coordinates of the region to plot.
 #' @param color_R2 Color the points according to R2 from the lead variant. Require R2 column in the pvalues_df data frame.
-#' @param data_track If TRUE, then remove all information from x-axis. 
-#' Makes it easy to append to read coverage or transcript strcture plots using cowplot::plot_grid(). 
+#' @param data_track If TRUE, then remove all information from x-axis.
+#' Makes it easy to append to read coverage or transcript strcture plots using cowplot::plot_grid().
 #'
 #' @return gglot2 object
 #' @examples
@@ -95,12 +100,12 @@ makeCoveragePlot <- function(coverage_df, limits, alpha, fill_palette, coverage_
 #' makeManhattanPlot(data, c(1,1000), data_track = FALSE)
 #' @export
 makeManhattanPlot <- function(pvalues_df, region_coords, color_R2 = FALSE, data_track = TRUE){
-  
+
   #Make assertions
   assertthat::assert_that(assertthat::has_name(pvalues_df, "track_id"))
   assertthat::assert_that(assertthat::has_name(pvalues_df, "p_nominal"))
   assertthat::assert_that(assertthat::has_name(pvalues_df, "pos"))
-  
+
   #If R2 is specified
   if(color_R2){
     assertthat::assert_that(assertthat::has_name(pvalues_df, "R2"))
@@ -109,16 +114,16 @@ makeManhattanPlot <- function(pvalues_df, region_coords, color_R2 = FALSE, data_
     #Else do not colour
     plot_base = ggplot(pvalues_df, aes_(x = ~pos, y = ~-log(p_nominal, 10))) + geom_blank()
   }
-  
+
   #Make the rest of the plot
-  plot = plot_base + 
+  plot = plot_base +
     facet_grid(track_id ~ .) +
-    geom_point() + 
-    theme_light() + 
+    geom_point() +
+    theme_light() +
     ylab(expression(paste("-",log[10], " p-value"))) +
     scale_x_continuous(expand = c(0,0)) +
     coord_cartesian(xlim = region_coords)
-  
+
   #Apply data track theme so that plots can later be pasted together with cowplot
   if(data_track){
     plot = plot + dataTrackTheme()

--- a/R/wiggleplotr.R
+++ b/R/wiggleplotr.R
@@ -2,8 +2,8 @@
 #'
 #' @param exons list of GRanges objects, each object containing exons for one transcript.
 #' The list must have names that correspond to transcript_id column in transript_annotations data.frame.
-#' @param cdss list of GRanges objects, each object containing the coding regions (CDS) of a single transcript. 
-#' The list must have names that correspond to transcript_id column in transript_annotations data.frame. 
+#' @param cdss list of GRanges objects, each object containing the coding regions (CDS) of a single transcript.
+#' The list must have names that correspond to transcript_id column in transript_annotations data.frame.
 #' If cdss is not specified then exons list will be used for both arguments. (default: NULL)
 #' @param transcript_annotations Data frame with at least three columns: transcript_id, gene_name, strand.
 #' Used to construct transcript labels. (default: NULL)
@@ -11,34 +11,34 @@
 #' @param new_intron_length length (bp) of introns after scaling. (default: 50)
 #' @param flanking_length Lengths of the flanking regions upstream and downstream of the gene. (default: c(50,50))
 #' @param connect_exons Print lines that connect exons together. Set to FALSE when plotting peaks (default: TRUE).
-#' @param transcript_label If TRUE then transcript labels are printed above each transcript. (default: TRUE). 
+#' @param transcript_label If TRUE then transcript labels are printed above each transcript. (default: TRUE).
 #' @param region_coords Start and end coordinates of the region to plot, overrides flanking_length parameter.
 #'
 #' @return ggplot2 object
 #' @examples
 #' plotTranscripts(ncoa7_exons, ncoa7_cdss, ncoa7_metadata, rescale_introns = FALSE)
-#' 
+#'
 #' @export
-plotTranscripts <- function(exons, cdss = NULL, transcript_annotations = NULL, 
-                            rescale_introns = TRUE, new_intron_length = 50, 
-                            flanking_length = c(50,50), connect_exons = TRUE, 
+plotTranscripts <- function(exons, cdss = NULL, transcript_annotations = NULL,
+                            rescale_introns = TRUE, new_intron_length = 50,
+                            flanking_length = c(50,50), connect_exons = TRUE,
                             transcript_label = TRUE, region_coords = NULL){
-  
+
   #IF cdss is not specified then use exons instead on cdss
   if(is.null(cdss)){
     cdss = exons
   }
-  
+
   #Check exons and cdss
   assertthat::assert_that(is.list(exons)|| is(exons, "GRangesList")) #Check that exons and cdss objects are lists
   assertthat::assert_that(is.list(cdss) || is(exons, "GRangesList"))
-  
+
   #Join exons together
   joint_exons = joinExons(exons)
-  
+
   #Extract chromosome name
   chromosome_name = as.vector(GenomicRanges::seqnames(joint_exons)[1])
-  
+
   #If region_coords is specificed, then ignore the flanking_length attrbute and compute
   # flanking_length form region_coords
   if(!is.null(region_coords)){
@@ -48,7 +48,7 @@ plotTranscripts <- function(exons, cdss = NULL, transcript_annotations = NULL,
     flanking_length = c(min_start - region_coords[1], region_coords[2] - max_end)
   }
   #Make sure that flanking_length is a vector of two elements
-  assertthat::assert_that(length(flanking_length) == 2) 
+  assertthat::assert_that(length(flanking_length) == 2)
 
   #Rescale introns
   if (rescale_introns){
@@ -58,10 +58,10 @@ plotTranscripts <- function(exons, cdss = NULL, transcript_annotations = NULL,
     old_introns = intronsFromJointExonRanges(GenomicRanges::ranges(joint_exons), flanking_length = flanking_length)
     tx_annotations = list(exon_ranges = lapply(exons, GenomicRanges::ranges), cds_ranges = lapply(cdss, GenomicRanges::ranges),
                           old_introns = old_introns, new_introns = old_introns)
-    
+
     xlabel = paste("Chromosome", chromosome_name, "position (bp)")
   }
-  
+
   #If transcript annotations are not supplied then construct them manually from the GRanges list
   if(is.null(transcript_annotations)){
     plotting_annotations = dplyr::tibble(transcript_id = names(exons),
@@ -70,89 +70,89 @@ plotTranscripts <- function(exons, cdss = NULL, transcript_annotations = NULL,
   } else{
     plotting_annotations = prepareTranscriptAnnotations(transcript_annotations)
   }
-  
+
   #Plot transcript structures
   limits = c( min(IRanges::start(tx_annotations$new_introns)), max(IRanges::end(tx_annotations$new_introns)))
-  structure = prepareTranscriptStructureForPlotting(tx_annotations$exon_ranges, 
+  structure = prepareTranscriptStructureForPlotting(tx_annotations$exon_ranges,
                                                tx_annotations$cds_ranges, plotting_annotations)
-  plot = plotTranscriptStructure(structure, limits, connect_exons = connect_exons, xlabel = xlabel, 
+  plot = plotTranscriptStructure(structure, limits, connect_exons = connect_exons, xlabel = xlabel,
                                  transcript_label = transcript_label)
   return(plot)
 }
 
 #' Plot read coverage across genomic regions
-#' 
-#' Also supports rescaling introns to constant length. Does not work 
+#'
+#' Also supports rescaling introns to constant length. Does not work
 #' on Windows, because rtracklayer cannot read BigWig files on Windows.
-#' 
-#' @param exons list of GRanges objects, each object containing exons for one transcript. 
+#'
+#' @param exons list of GRanges objects, each object containing exons for one transcript.
 #' The list must have names that correspond to transcript_id column in transript_annotations data.frame.
-#' @param cdss list of GRanges objects, each object containing the coding regions (CDS) of a single transcript. 
-#' The list must have names that correspond to transcript_id column in transript_annotations data.frame. 
+#' @param cdss list of GRanges objects, each object containing the coding regions (CDS) of a single transcript.
+#' The list must have names that correspond to transcript_id column in transript_annotations data.frame.
 #' If cdss is not specified then exons list will be used for both arguments. (default: NULL).
-#' @param transcript_annotations Data frame with at least three columns: transcript_id, gene_name, strand. 
+#' @param transcript_annotations Data frame with at least three columns: transcript_id, gene_name, strand.
 #' Used to construct transcript labels. (default: NULL)
 #' @param track_data data.frame with the metadata for the bigWig read coverage files. Must contain the following columns:
 #' \itemize{
 #'  \item sample_id - unique id for each sample.
-#'  \item track_id - if multiple samples (bigWig files) have the same track_id they will be overlayed on the same 
+#'  \item track_id - if multiple samples (bigWig files) have the same track_id they will be overlayed on the same
 #' plot, track_id is also used as the facet label on the right.
 #'  \item bigWig - path to the bigWig file.
-#'  \item scaling_factor - normalisation factor for each sample, useful if different samples sequenced to different 
+#'  \item scaling_factor - normalisation factor for each sample, useful if different samples sequenced to different
 #' depth and bigWig files not normalised for that.
 #'  \item colour_group - additional column to group samples into, is used as the colour of the coverage track.
 #' }
 #' @param rescale_introns Specifies if the introns should be scaled to fixed length or not. (default: TRUE)
 #' @param new_intron_length length (bp) of introns after scaling. (default: 50)
 #' @param flanking_length Lengths of the flanking regions upstream and downstream of the gene. (default: c(50,50))
-#' @param plot_fraction Size of the random sub-sample of points used to plot coverage (between 0 and 1). 
+#' @param plot_fraction Size of the random sub-sample of points used to plot coverage (between 0 and 1).
 #' Smaller values make plotting significantly faster. (default: 0.1)
-#' @param heights  Specifies the proportion of the height that is dedicated to coverage plots (first value) 
+#' @param heights  Specifies the proportion of the height that is dedicated to coverage plots (first value)
 #' relative to transcript annotations (second value). (default: c(0.75,0.25))
-#' @param alpha Transparency (alpha) value for the read coverage tracks. 
+#' @param alpha Transparency (alpha) value for the read coverage tracks.
 #' Useful to set to something < 1 when overlaying multiple tracks (see track_id). (default: 1)
-#' @param fill_palette Vector of fill colours used for the coverage tracks. Length must be equal to the number of 
+#' @param fill_palette Vector of fill colours used for the coverage tracks. Length must be equal to the number of
 #' unique values in track_data$colour_group column.
-#' @param mean_only Plot only mean coverage within each combination of track_id and colour_group values. 
+#' @param mean_only Plot only mean coverage within each combination of track_id and colour_group values.
 #' Useful for example for plotting mean coverage stratified by genotype (which is specified in the colour_group column) (default: TRUE).
 #' @param connect_exons Print lines that connect exons together. Set to FALSE when plotting peaks (default: TRUE).
-#' @param transcript_label If TRUE then transcript labels are printed above each transcript. (default: TRUE). 
-#' @param return_subplots_list Instead of a joint plot return a list of subplots that can be joined together manually. 
+#' @param transcript_label If TRUE then transcript labels are printed above each transcript. (default: TRUE).
+#' @param return_subplots_list Instead of a joint plot return a list of subplots that can be joined together manually.
 #' @param region_coords Start and end coordinates of the region to plot, overrides flanking_length parameter.
-#' @param coverage_type Specifies if the read coverage is represented by either 'line', 'area' or 'both'. 
-#' The 'both' option tends to give better results for wide regions. (default: area). 
+#' @param coverage_type Specifies if the read coverage is represented by either 'line', 'area' or 'both'.
+#' The 'both' option tends to give better results for wide regions. (default: area).
 #'
 #' @return Either object from cow_plot::plot_grid() function or a list of subplots (if return_subplots_list == TRUE)
 #' @examples
 #' require("dplyr")
 #' require("GenomicRanges")
-#' sample_data = dplyr::data_frame(sample_id = c("aipt_A", "aipt_C", "bima_A", "bima_C"), 
-#'     condition = factor(c("Naive", "LPS", "Naive", "LPS"), levels = c("Naive", "LPS")), 
+#' sample_data = dplyr::data_frame(sample_id = c("aipt_A", "aipt_C", "bima_A", "bima_C"),
+#'     condition = factor(c("Naive", "LPS", "Naive", "LPS"), levels = c("Naive", "LPS")),
 #'     scaling_factor = 1) %>%
 #'     dplyr::mutate(bigWig = system.file("extdata",  paste0(sample_id, ".str2.bw"), package = "wiggleplotr"))
-#' 
+#'
 #' track_data = dplyr::mutate(sample_data, track_id = condition, colour_group = condition)
-#' 
+#'
 #' selected_transcripts = c("ENST00000438495", "ENST00000392477") #Plot only two transcripts of the gens
 #' \dontrun{
-#' plotCoverage(ncoa7_exons[selected_transcripts], ncoa7_cdss[selected_transcripts], 
-#'    ncoa7_metadata, track_data, 
+#' plotCoverage(ncoa7_exons[selected_transcripts], ncoa7_cdss[selected_transcripts],
+#'    ncoa7_metadata, track_data,
 #'    heights = c(2,1), fill_palette = getGenotypePalette())
 #' }
-#' 
+#'
 #' @export
 plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, track_data, rescale_introns = TRUE,
                         new_intron_length = 50, flanking_length = c(50,50),
                         plot_fraction = 0.1, heights = c(0.75, 0.25), alpha = 1,
-                        fill_palette = c("#a1dab4","#41b6c4","#225ea8"), mean_only = TRUE, 
+                        fill_palette = c("#a1dab4","#41b6c4","#225ea8"), mean_only = TRUE,
                         connect_exons = TRUE, transcript_label = TRUE, return_subplots_list = FALSE,
                         region_coords = NULL, coverage_type = "area"){
-  
+
   #IF cdss is not specified then use exons instead on cdss
   if(is.null(cdss)){
     cdss = exons
   }
-  
+
   #Make some assertions about the input data
   #Check track_data
   assertthat::assert_that(assertthat::has_name(track_data, "sample_id"))
@@ -160,13 +160,13 @@ plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, trac
   assertthat::assert_that(assertthat::has_name(track_data, "bigWig"))
   assertthat::assert_that(assertthat::has_name(track_data, "scaling_factor"))
   assertthat::assert_that(assertthat::has_name(track_data, "colour_group"))
-  
+
   #Make sure that bigWig column is not a factor
   if(is.factor(track_data$bigWig)){
     warning("bigWig column in track_data data.frame is a factor, coverting to a character vector.")
     track_data = dplyr::mutate_(track_data, .dots = stats::setNames(list(~as.character(bigWig)), c("bigWig")))
   }
-  
+
   #Check transcript annotation
   #If transcript annotations are not supplied then construct them manually from the GRanges list
   if(is.null(transcript_annotations)){
@@ -179,15 +179,15 @@ plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, trac
     assertthat::assert_that(assertthat::has_name(transcript_annotations, "strand"))
     plotting_annotations = prepareTranscriptAnnotations(transcript_annotations)
   }
-  
+
   #Check exons and cdss
   assertthat::assert_that(is.list(exons) || is(exons, "GRangesList")) #Check that exons and cdss objects are lists
   assertthat::assert_that(is.list(cdss) || is(exons, "GRangesList"))
   #TODO: Check that the names of the exons and cdss list match that of the transcript_annotations data.frame
-  
+
   #Find the start and end cooridinates of the whole region spanning the gene
   joint_exons = joinExons(exons)
-  
+
   #If region_coords is specificed, then ignore the flanking_length attrbute and compute
   # flanking_length form region_coords
   if(!is.null(region_coords)){
@@ -195,7 +195,7 @@ plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, trac
     min_start = min(GenomicRanges::start(gene_range))
     max_end = max(GenomicRanges::end(gene_range))
     flanking_length = c(min_start - region_coords[1], region_coords[2] - max_end)
-    
+
     gene_range = constructGeneRange(joint_exons, flanking_length)
   } else{
     gene_range = constructGeneRange(joint_exons, flanking_length)
@@ -213,7 +213,7 @@ plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, trac
   #Shorten introns and translate exons into the new introns
   if(rescale_introns){
     #Recale transcript annotations
-    tx_annotations = rescaleIntrons(exons, cdss, joint_exons, 
+    tx_annotations = rescaleIntrons(exons, cdss, joint_exons,
                                     new_intron_length = new_intron_length, flanking_length = flanking_length)
     #Make a label for gene structure plot
     xlabel = "Distance from region start (bp)"
@@ -223,7 +223,7 @@ plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, trac
     old_introns = intronsFromJointExonRanges(GenomicRanges::ranges(joint_exons), flanking_length = flanking_length)
     tx_annotations = list(exon_ranges = lapply(exons, GenomicRanges::ranges), cds_ranges = lapply(cdss, GenomicRanges::ranges),
                           old_introns = old_introns, new_introns = old_introns)
-    
+
     #Make a label for gene structure plot
     xlabel = paste("Chromosome", chromosome_name, "position (bp)")
   }
@@ -235,7 +235,7 @@ plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, trac
   coverage_list = lapply(coverage_list, function(x) {x[points,]} )
 
   #Convert to data frame and plot
-  coverage_df = purrr::map_df(coverage_list, identity, .id = "sample_id") %>% 
+  coverage_df = purrr::map_df(coverage_list, identity, .id = "sample_id") %>%
     as.data.frame() %>%
     dplyr::mutate_(.dots = stats::setNames(list(~as.character(sample_id)), c("sample_id")) ) #Convert factor to character
   coverage_df = dplyr::left_join(coverage_df, track_data, by = "sample_id") %>%
@@ -243,16 +243,24 @@ plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, trac
 
   #Calculate mean coverage within each track and colour group
   if(mean_only){  coverage_df = meanCoverage(coverage_df) }
-  
+
   #Make plots
   #Construct transcript structure data.frame from ranges lists
   limits = c( min(IRanges::start(tx_annotations$new_introns)), max(IRanges::end(tx_annotations$new_introns)))
-  transcript_struct = prepareTranscriptStructureForPlotting(tx_annotations$exon_ranges, 
+  transcript_struct = prepareTranscriptStructureForPlotting(tx_annotations$exon_ranges,
                        tx_annotations$cds_ranges, plotting_annotations)
+
+  if(unique(transcript_struct$strand) == -1){
+    transcript_struct <-
+      transcript_struct %>%
+      dplyr::mutate(transcript_label = paste0(sub("< ", "", transcript_label), " >"))
+    limits = rev(limits)
+  }
+
   tx_structure = plotTranscriptStructure(transcript_struct, limits, connect_exons, xlabel, transcript_label)
-  
+
   coverage_plot = makeCoveragePlot(coverage_df, limits, alpha, fill_palette, coverage_type)
-  
+
   #Choose between returning plot list or a joint plot using plot_grid
   if(return_subplots_list){
     plot_list = list(coverage_plot = coverage_plot, tx_structure = tx_structure)
@@ -262,4 +270,4 @@ plotCoverage <- function(exons, cdss = NULL, transcript_annotations = NULL, trac
     return(plot)
   }
 }
-  
+


### PR DESCRIPTION
I am opening this request to add the capacity to plot coverage and transcript structure oriented by strand. Currently wiggleplotr always renders plots according to genomic coordinates as would be the case in most genome browsers. Typically users in my lab prefer to read coverage from left to right, with the leftmost exon being the first in the transcript.

This PR flips coverage plots based on the strand of the included transcripts. This is accomplished by flipping plot limits depending on strand identity. Additionally, transcript labels are reformatted and relocated depending on strand. 

I haven't added changes to manhattan plots. I guess also that this solution is not robust to cases where a user plots coverage of multiple genes lying on conflicting strands. If this is a common use case, perhaps an option could be added to flip coverage as an argument in `plotCoverage`?